### PR TITLE
Handle empty category draws

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,6 +325,7 @@
 
     function dealOne(){
       const pool = filterDeck();
+      if (!pool.length){ toast('No cards in this category.'); return; }
       const card = sample(pool);
       state.history.push(card);
       renderCard(card);
@@ -332,6 +333,7 @@
 
     function dealThree(){
       const pool = [...filterDeck()];
+      if (!pool.length){ toast('No cards in this category.'); return; }
       const picks=[];
       while (picks.length<3 && pool.length){
         const idx=r(0,pool.length-1); picks.push(pool.splice(idx,1)[0]);


### PR DESCRIPTION
## Summary
- guard draw helpers against empty categories by showing a toast when no cards are available

## Testing
- `npx --yes htmlhint index.html` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_6897134d5190832d980e29cb36f55cfe