### PR TITLE
Fix missing comma preventing card display

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
       { id:'inclusion', name:'Inclusion & Representation' },
       { id:'ideo', name:'IDEO Lenses (D/F/V)' },
       { id:'humankind', name:'Leo Burnett — HumanKind' },
-      { id:'provocation', name:'Sharp Provocations' }
+      { id:'provocation', name:'Sharp Provocations' },
       { id:'challenger', name:'Eat Big Fish — Challenger' },
     ];
 


### PR DESCRIPTION
## Summary
- restore categories array syntax by adding missing comma after 'Sharp Provocations'

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68971fe259dc832da8efd26d94397912